### PR TITLE
Fix JSON schema for target system type

### DIFF
--- a/Schemas/MDR Schema.json
+++ b/Schemas/MDR Schema.json
@@ -485,8 +485,7 @@
                                     },
                                     "system": {
                                         "title": "Target system for the search",
-                                        "type": "string",
-                                        "enum": []
+                                        "type": "string"
                                     },
                                     "query": {
                                         "title": "\ud83d\udd0e Supporting Search Query",

--- a/Schemas/MDR Schema.json
+++ b/Schemas/MDR Schema.json
@@ -485,7 +485,15 @@
                                     },
                                     "system": {
                                         "title": "Target system for the search",
-                                        "type": "string"
+                                        "type": "string",
+                                        "enum": [
+                                            "splunk",
+                                            "sentinel",
+                                            "crowdstrike",
+                                            "sentinel_one",
+                                            "defender_for_endpoint",
+                                            "carbon_black_cloud"
+                                        ]
                                     },
                                     "query": {
                                         "title": "\ud83d\udd0e Supporting Search Query",


### PR DESCRIPTION
The enum without values was breaking the VS code schema validation. Because of this, I've added the what I belive are the allowed systems currently. 

* Added a list of allowed values to the `system` field's `enum` in `Schemas/MDR Schema.json`, specifying supported systems: `splunk`, `sentinel`, `crowdstrike`, `sentinel_one`, `defender_for_endpoint`, and `carbon_black_cloud`.